### PR TITLE
Update key_actions.py

### DIFF
--- a/plugin/addons/key_actions.py
+++ b/plugin/addons/key_actions.py
@@ -704,7 +704,7 @@ class key_actions(stat_info):
 			if stat.f_bavail * stat.f_bsize > 1000000:
 				choice.append((_("Show as Picture and save as file ('%s')")%self.tmp_file , "save"))
 				savetext = _(" or save the picture additionally to a file")
-			self.session.openWithCallback(self.mviFileCB, MessageBox, _("Show '%s' as picture%s?\nThe current service must be interrupted!") %(longname,savetext), simple=True, list=choice, simple=True)
+			self.session.openWithCallback(self.mviFileCB, MessageBox, _("Show '%s' as picture%s?\nThe current service must be interrupted!") %(longname,savetext), simple=True, list=choice)
 		elif filetype in TEXT_EXTENSIONS or config.plugins.filecommander.unknown_extension_as_text.value:
 			try:
 				xfile = os.stat(longname)


### PR DESCRIPTION
FileCommander/addons/key_actions.py", line 707
self.session.openWithCallback(self.mviFileCB, MessageBox, _("Show '%s' as picture%s?\nThe current service must be interrupted!") %(longname,savetext), simple=True, list=choice, simple=True)
SyntaxError: keyword argument repeated