### PR TITLE
Console.py: Convert str to unicode

### DIFF
--- a/plugin/Console.py
+++ b/plugin/Console.py
@@ -216,4 +216,4 @@ class Console(Screen):
 				self.container.kill()
 
 	def dataAvail(self, str):
-		self["text"].appendText(str)
+		self["text"].appendText(str.decode())


### PR DESCRIPTION
File "/usr/lib/enigma2/python/Plugins/Extensions/FileCommander/Console.py", line 218, in dataAvail
    self["text"].appendText(str)
  File "/usr/lib/enigma2/python/Components/ScrollLabel.py", line 113, in appendText
    self.setText(self.message + text, showBottom)
TypeError: can only concatenate str (not "bytes") to str